### PR TITLE
Fix the environment to amd64 for linux containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   db_service:
+    platform: linux/amd64
     image: postgres:13
     ports:
       - "5432:5432"
@@ -9,9 +10,11 @@ services:
       - postgresql_data:/var/lib/postgresql/data/
 
   redis:
+    platform: linux/amd64
     image: redis:alpine
 
   frontend:
+    platform: linux/amd64
     build: ./frontend
     ports:
       - "5173:5173"
@@ -24,6 +27,7 @@ services:
       - /app/node_modules
 
   backend:
+    platform: linux/amd64
     build: ./backend
     ports:
       - "5001:5001"


### PR DESCRIPTION
This is configures through the platform.
Otherwise, docker will by default use arm containers when used on a arm host.

Fixes #11 