### PR TITLE
Add pyroomacoustics as simulation backend

### DIFF
--- a/CHORAS_BUILD.sh
+++ b/CHORAS_BUILD.sh
@@ -11,7 +11,7 @@ echo "Docker image exported to dg_image.tar"
 docker save -o backend/app/services/executors/de_image.tar de_image:latest
 echo "Docker image exported to de_image.tar"
 
-# docker save -o backend/app/services/executors/pa_image.tar pa_image:latest
-# echo "Docker image exported to pa_image.tar"
+docker save -o backend/app/services/executors/pyroomacoustics_image.tar pyroomacoustics_image:latest
+echo "Docker image exported to pyroomacoustics_image.tar"
 
 docker compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,5 +65,15 @@ services:
     profiles:
       - sim_method # Skipped in docker compose up
 
+  # BUILD-ONLY: pyroomacoustics simulation (profile: sim_method)
+  pyroomacoustics-method:
+    platform: linux/amd64
+    build:
+      context: ./simulation-backend
+      dockerfile: pyroomacoustics_method/Dockerfile
+    image: pyroomacoustics_image:latest
+    profiles:
+      - sim_method # Skipped in docker compose up
+
 volumes:
   postgresql_data:


### PR DESCRIPTION
The corresponding interface implementation is finalized in https://github.com/choras-org/simulation-backend/pull/4

This PR does not contain bumping to the required submodules.