### PR TITLE
MAINT: Add uploads folder to gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# local app folders and links
+uploads
+
+# macOS
 .DS_Store
 
 # Byte-compiled / optimized / DLL files


### PR DESCRIPTION
### Proposed changes

Add the uploads folder to the gitignore file.
This folder links to the backend docker container volume. 